### PR TITLE
fixing auth timing out after 5 minutes

### DIFF
--- a/e2e_tests/course_access.spec.ts
+++ b/e2e_tests/course_access.spec.ts
@@ -58,8 +58,12 @@ test.describe("learner", async () => {
 
     for (const article of articles) {
       await page.getByRole("link", { name: article.title, exact: true }).click();
+
       expect(page.url()).toContain(`/courses/2/access/${article.id}`);
+      expect(page.getByText("Purchase to access")).not.toBeVisible();
+
       expectCount++;
+
     }
 
     expect(expectCount).toBe(3);

--- a/src/stores/main_store.rs
+++ b/src/stores/main_store.rs
@@ -12,10 +12,10 @@ use yewdux::prelude::*;
 
 static STATE_COOKIE_KEY: &str = "auth_state";
 static TOKEN_COOKIE_KEY: &str = "auth_token";
-static STATE_COOKIE_MAX_LIFE: u32 = 60 * 5;
 static AUTH0_DOMAIN: &str = dotenv!("AUTH0_DOMAIN");
 static AUTH0_LOGOUT_REDIRECT: &str = dotenv!("LOGOUT_REDIRECT");
 static AUTH0_CLIENT_ID: &str = dotenv!("AUTH0_CLIENT_ID");
+static TOKEN_COOKIE_MAX_LIFE: u32 = 60 * 60 * 24;
 
 #[derive(Store, Default, Clone, PartialEq)]
 pub struct MainStore {
@@ -116,7 +116,7 @@ pub async fn login_from_redirect(dispatch: Dispatch<MainStore>) {
                 }
 
                 if let Err(error) =
-                    save_cookie(TOKEN_COOKIE_KEY, &access_token, STATE_COOKIE_MAX_LIFE)
+                    save_cookie(TOKEN_COOKIE_KEY, &access_token, TOKEN_COOKIE_MAX_LIFE)
                 {
                     log_error("Error saving token to cookie", &error);
                 }


### PR DESCRIPTION
- testing that the Login to Purchase button only shows up if you don't own the course
- Keeping user logged in for 24 hours
