### PR TITLE
Clearing content text area when submitting new article

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,7 +1716,7 @@ checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 [[package]]
 name = "ycl"
 version = "0.1.0"
-source = "git+https://github.com/brooks-builds/ycl?rev=e88f5c8#e88f5c8b0dbaf064ca9f66b70020ff8076c34894"
+source = "git+https://github.com/brooks-builds/ycl?rev=81601fa#81601fab8ad776cedf903f92f0dfc8068f2ab572"
 dependencies = [
  "chrono",
  "gloo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 yew = { version = "0.20.0", features = ["csr"] }
-ycl = { git = "https://github.com/brooks-builds/ycl", rev = "e88f5c8" }
+ycl = { git = "https://github.com/brooks-builds/ycl", rev = "81601fa" }
 # ycl = { path = "../ycl/" }
 yew-router = "0.17.0"
 gloo = "0.8.0"

--- a/e2e_tests/create_article.spec.ts
+++ b/e2e_tests/create_article.spec.ts
@@ -85,6 +85,9 @@ test.describe("Authors", async () => {
 
     expect(intercepted).toBe(true);
     expect(await page.getByText("created").isVisible()).toBe(true);
+
+    expect(await page.getByLabel("Title").inputValue()).toBe("");
+    expect(await page.getByLabel("Article Body").inputValue()).toBe("");
   });
 
   test("cannot create an article without title", async ({

--- a/src/pages/create_article.rs
+++ b/src/pages/create_article.rs
@@ -44,6 +44,8 @@ pub fn component() -> Html {
     }
 
     let onsubmit = {
+        let title_store = title.clone();
+
         Callback::from(move |form: FormData| {
             let Some(title) = form.get("title").as_string() else {
                 main_store::error_alert(dispatch.clone(), "missing title");
@@ -69,6 +71,8 @@ pub fn component() -> Html {
                     main_store::insert_article(dispatch, title.into(), content.into()).await
                 });
             }
+
+            title_store.set(AttrValue::from(""));
         })
     };
 

--- a/src/pages/create_article.rs
+++ b/src/pages/create_article.rs
@@ -43,8 +43,16 @@ pub fn component() -> Html {
         })
     }
 
+    let content_value = use_state(|| AttrValue::from(""));
+    let content_oninput = {
+        let value = content_value.clone();
+
+        Callback::from(move |new_value| value.set(new_value))
+    };
+
     let onsubmit = {
         let title_store = title.clone();
+        let content_value = content_value.clone();
 
         Callback::from(move |form: FormData| {
             let Some(title) = form.get("title").as_string() else {
@@ -73,6 +81,7 @@ pub fn component() -> Html {
             }
 
             title_store.set(AttrValue::from(""));
+            content_value.set(AttrValue::from(""));
         })
     };
 
@@ -97,6 +106,8 @@ pub fn component() -> Html {
                     id="body"
                     label="Article Body"
                     name="content"
+                    value={content_value.deref().clone()}
+                    oninput={content_oninput}
                 />
                 <BBButton button_style={BBButtonStyle::PrimaryLight} button_type={BBButtonType::Submit}>{"Create Article"}</BBButton>
             </BBForm>


### PR DESCRIPTION
- clearing out article title on create. Still need to clear out the content. Most likely need to update the YCL to enable this
- creating article and course text areas now clear when submitting
